### PR TITLE
add calendar extension

### DIFF
--- a/7.1/alpine/Dockerfile
+++ b/7.1/alpine/Dockerfile
@@ -18,7 +18,7 @@ RUN echo no | pecl install redis && \
     docker-php-ext-enable redis memcached
 
 ##### Install php extension packages
-RUN docker-php-ext-install mysqli opcache gd bz2 zip intl pdo_mysql bcmath pgsql pdo_pgsql
+RUN docker-php-ext-install mysqli opcache gd bz2 zip intl pdo_mysql bcmath pgsql pdo_pgsql calendar
 
 ###### set up timezone
 RUN rm /etc/localtime && \

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -18,7 +18,7 @@ RUN echo no | pecl install redis && \
     docker-php-ext-enable redis memcached
 
 ##### Install php extension packages
-RUN docker-php-ext-install mysqli opcache gd bz2 zip intl pdo_mysql bcmath pgsql pdo_pgsql
+RUN docker-php-ext-install mysqli opcache gd bz2 zip intl pdo_mysql bcmath pgsql pdo_pgsql calendar
 
 ###### set up timezone
 RUN rm /etc/localtime && \


### PR DESCRIPTION
报表同事发现dev环境的镜像没有calendar扩展，导致营业额tc分析表、营销报表--企业营收趋势表查不出数据。
我看了dev环境的container，php -m没查到calendar扩展；但是prod环境，相同的container，却存在calendar扩展。唯一可能的解释是dev环境我会用docker-compose pull更新image；而prod环境不会更新。
为了解决这个问题，建议在基础镜像里面装上calendar扩展。